### PR TITLE
fix null literal in JawaObject toJSON

### DIFF
--- a/JawaScriptExecutive-iOS/JawaObject.m
+++ b/JawaScriptExecutive-iOS/JawaObject.m
@@ -109,7 +109,7 @@ NSMutableDictionary* objectPrototype;
         [ret appendString:key];
         [ret appendString:@"\":"];
         JawaObjectRef* value = [self.properties objectForKey:key];
-        if (value == nil)
+        if (value == nil || value.object == nil)
             [ret appendString:@"null"];
         else if ([value.object isKindOfClass:[NSString class]]) {
             [ret appendString:@"\""];


### PR DESCRIPTION
ret append nill when value.object is null, which happends when value is null literal.
